### PR TITLE
Joomla 4 "Call to undefined method Joomla\CMS\Application\SiteApplication::isSite() "

### DIFF
--- a/prismsyntaxhighlighter.php
+++ b/prismsyntaxhighlighter.php
@@ -18,7 +18,7 @@ class plgContentprismsyntaxhighlighter extends JPlugin
 				if ($matches)
 					{
 						$app = JFactory::getApplication();
-						if ($app->isSite())
+						if ($app->isClient('site'))
 							{
 								$document = JFactory::getDocument();
 								$document->addStyleSheet(JURI::base($pathonly=true).'/media/plg_content_prismsyntaxhighlighter/css/prism-' . $this->params->def('prismstyle','default') .'.css');


### PR DESCRIPTION
I tried to use your plugin only for loading prism.css and .js in front-end after adding a code sample snippet via TinyMCE in current Joomla 4 nightly build.

the fix works also with J3.9+

Error is:
Call to undefined method Joomla\CMS\Application\SiteApplication::isSite() 

Call stack
--
# | Function | Location
1 | () | JROOT/plugins/content/prismsyntaxhighlighter/prismsyntaxhighlighter.php:21
2 | plgContentprismsyntaxhighlighter->onContentPrepare() | JROOT/libraries/src/Plugin/CMSPlugin.php:285
3 | Joomla\CMS\Plugin\CMSPlugin->Joomla\CMS\Plugin\{closure}() | JROOT/libraries/vendor/joomla/event/src/Dispatcher.php:495
4 | Joomla\Event\Dispatcher->dispatch() | JROOT/libraries/src/Application/EventAware.php:111
5 | Joomla\CMS\Application\WebApplication->triggerEvent() | JROOT/components/com_content/src/View/Article/HtmlView.php:243
6 | Joomla\Component\Content\Site\View\Article\HtmlView->display() | JROOT/libraries/src/MVC/Controller/BaseController.php:691

